### PR TITLE
Add C# stubs for item publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# .NET
+**/bin/
+**/obj/

--- a/FabricCicd.Console/Fabric/Common/File.cs
+++ b/FabricCicd.Console/Fabric/Common/File.cs
@@ -1,0 +1,21 @@
+namespace FabricCicd.Common;
+
+/// <summary>
+/// Represents a file belonging to an item.
+/// This is a very small subset of the Python implementation.
+/// </summary>
+public class File
+{
+    public string ItemPath { get; }
+    public string FilePath { get; }
+    public string Type { get; }
+    public string Contents { get; }
+
+    public File(string itemPath, string filePath, string type = "text", string contents = "")
+    {
+        ItemPath = itemPath;
+        FilePath = filePath;
+        Type = type;
+        Contents = contents;
+    }
+}

--- a/FabricCicd.Console/Fabric/Common/Item.cs
+++ b/FabricCicd.Console/Fabric/Common/Item.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace FabricCicd.Common;
+
+/// <summary>
+/// Represents a deployable item in the workspace.
+/// </summary>
+public class Item
+{
+    public string Type { get; }
+    public string Name { get; }
+    public string Description { get; }
+    public string Guid { get; }
+    public IList<File> ItemFiles { get; } = new List<File>();
+
+    public Item(string type, string name, string description, string guid)
+    {
+        Type = type;
+        Name = name;
+        Description = description;
+        Guid = guid;
+    }
+}

--- a/FabricCicd.Console/Fabric/Constants.cs
+++ b/FabricCicd.Console/Fabric/Constants.cs
@@ -1,0 +1,47 @@
+namespace FabricCicd;
+
+/// <summary>
+/// Mirrors values from constants.py.
+/// </summary>
+public static class Constants
+{
+    public const string Version = "0.1.19";
+    public const string DefaultWorkspaceId = "00000000-0000-0000-0000-000000000000";
+    public const string DefaultApiRootUrl = "https://api.powerbi.com";
+    public static readonly HashSet<string> FeatureFlag = new();
+
+    public static readonly string[] AcceptedItemTypesUpn =
+    {
+        "DataPipeline",
+        "Environment",
+        "Notebook",
+        "Report",
+        "SemanticModel",
+        "Lakehouse",
+        "MirroredDatabase",
+        "VariableLibrary",
+        "CopyJob",
+        "Eventhouse",
+        "KQLDatabase",
+        "KQLQueryset",
+        "Reflex",
+        "Eventstream",
+        "Warehouse",
+        "SQLDatabase",
+    };
+
+    public static readonly IReadOnlyDictionary<string, int> MaxRetryOverride = new Dictionary<string, int>
+    {
+        ["SemanticModel"] = 10,
+        ["Report"] = 10,
+        ["Eventstream"] = 10,
+        ["KQLDatabase"] = 10,
+        ["VariableLibrary"] = 7,
+        ["SQLDatabase"] = 7,
+    };
+
+    public static readonly string[] ShellOnlyPublish =
+        { "Environment", "Lakehouse", "Warehouse", "SQLDatabase" };
+
+    public static readonly string UserAgent = $"ms-fabric-cicd/{Version}";
+}

--- a/FabricCicd.Console/Fabric/FabricWorkspace.cs
+++ b/FabricCicd.Console/Fabric/FabricWorkspace.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace FabricCicd;
+
+/// <summary>
+/// Simplified representation of FabricWorkspace from the Python library.
+/// </summary>
+public class FabricWorkspace
+{
+    public string WorkspaceId { get; }
+    public string RepositoryDirectory { get; }
+    public IList<string> ItemTypes { get; }
+
+    public FabricWorkspace(string workspaceId, string repositoryDirectory, IEnumerable<string> itemTypes)
+    {
+        WorkspaceId = workspaceId ?? throw new ArgumentNullException(nameof(workspaceId));
+        RepositoryDirectory = repositoryDirectory ?? throw new ArgumentNullException(nameof(repositoryDirectory));
+        ItemTypes = itemTypes?.ToList() ?? throw new ArgumentNullException(nameof(itemTypes));
+    }
+
+    // TODO: Add full implementation of methods from fabric_workspace.py
+    public void RefreshRepositoryItems()
+    {
+        // Placeholder for scanning repo directory
+    }
+
+    public void RefreshDeployedItems()
+    {
+        // Placeholder for calling Fabric API
+    }
+
+    public void PublishItem(string name, string itemType)
+    {
+        // Placeholder publish logic
+        Console.WriteLine($"Publishing {itemType} {name}");
+    }
+
+    public void UnpublishItem(string name, string itemType)
+    {
+        // Placeholder unpublish logic
+        Console.WriteLine($"Unpublishing {itemType} {name}");
+    }
+}

--- a/FabricCicd.Console/Fabric/Items/ItemPublishers.cs
+++ b/FabricCicd.Console/Fabric/Items/ItemPublishers.cs
@@ -1,0 +1,74 @@
+namespace FabricCicd.Items;
+
+/// <summary>
+/// Collection of helper methods that mirror the item specific publish logic
+/// from the Python implementation. The methods here are simplified stubs.
+/// </summary>
+public static class ItemPublishers
+{
+    public static void PublishNotebooks(FabricWorkspace ws)
+    {
+        foreach (var name in ws.ItemTypes)
+        {
+            if (name == "Notebook")
+            {
+                ws.PublishItem("all", "Notebook");
+            }
+        }
+    }
+
+    public static void PublishReports(FabricWorkspace ws)
+    {
+        foreach (var name in ws.ItemTypes)
+        {
+            if (name == "Report")
+            {
+                ws.PublishItem("all", "Report");
+            }
+        }
+    }
+
+    public static void PublishDataPipelines(FabricWorkspace ws)
+    {
+        foreach (var name in ws.ItemTypes)
+        {
+            if (name == "DataPipeline")
+            {
+                ws.PublishItem("all", "DataPipeline");
+            }
+        }
+    }
+
+    public static void PublishEnvironments(FabricWorkspace ws)
+    {
+        foreach (var name in ws.ItemTypes)
+        {
+            if (name == "Environment")
+            {
+                ws.PublishItem("all", "Environment");
+            }
+        }
+    }
+
+    // Additional item types below are implemented as no-op placeholders
+    public static void PublishActivators(FabricWorkspace ws) => PublishGeneric(ws, "Reflex");
+    public static void PublishCopyJobs(FabricWorkspace ws) => PublishGeneric(ws, "CopyJob");
+    public static void PublishEventhouses(FabricWorkspace ws) => PublishGeneric(ws, "Eventhouse");
+    public static void PublishEventstreams(FabricWorkspace ws) => PublishGeneric(ws, "Eventstream");
+    public static void PublishKqlDatabases(FabricWorkspace ws) => PublishGeneric(ws, "KQLDatabase");
+    public static void PublishKqlQuerysets(FabricWorkspace ws) => PublishGeneric(ws, "KQLQueryset");
+    public static void PublishLakehouses(FabricWorkspace ws) => PublishGeneric(ws, "Lakehouse");
+    public static void PublishMirroredDatabase(FabricWorkspace ws) => PublishGeneric(ws, "MirroredDatabase");
+    public static void PublishSemanticModels(FabricWorkspace ws) => PublishGeneric(ws, "SemanticModel");
+    public static void PublishSqlDatabases(FabricWorkspace ws) => PublishGeneric(ws, "SQLDatabase");
+    public static void PublishVariableLibraries(FabricWorkspace ws) => PublishGeneric(ws, "VariableLibrary");
+    public static void PublishWarehouses(FabricWorkspace ws) => PublishGeneric(ws, "Warehouse");
+
+    private static void PublishGeneric(FabricWorkspace ws, string type)
+    {
+        if (ws.ItemTypes.Contains(type))
+        {
+            ws.PublishItem("all", type);
+        }
+    }
+}

--- a/FabricCicd.Console/Fabric/Publish.cs
+++ b/FabricCicd.Console/Fabric/Publish.cs
@@ -1,0 +1,42 @@
+using System;
+using FabricCicd.Items;
+
+namespace FabricCicd;
+
+public static class Publish
+{
+    /// <summary>
+    /// Placeholder implementation of publish_all_items.
+    /// </summary>
+    public static void PublishAllItems(FabricWorkspace workspace)
+    {
+        workspace.RefreshDeployedItems();
+        workspace.RefreshRepositoryItems();
+
+        Items.ItemPublishers.PublishVariableLibraries(workspace);
+        Items.ItemPublishers.PublishWarehouses(workspace);
+        Items.ItemPublishers.PublishLakehouses(workspace);
+        Items.ItemPublishers.PublishSqlDatabases(workspace);
+        Items.ItemPublishers.PublishMirroredDatabase(workspace);
+        Items.ItemPublishers.PublishEnvironments(workspace);
+        Items.ItemPublishers.PublishNotebooks(workspace);
+        Items.ItemPublishers.PublishSemanticModels(workspace);
+        Items.ItemPublishers.PublishReports(workspace);
+        Items.ItemPublishers.PublishDataPipelines(workspace);
+        Items.ItemPublishers.PublishCopyJobs(workspace);
+        Items.ItemPublishers.PublishEventhouses(workspace);
+        Items.ItemPublishers.PublishKqlDatabases(workspace);
+        Items.ItemPublishers.PublishKqlQuerysets(workspace);
+        Items.ItemPublishers.PublishActivators(workspace);
+        Items.ItemPublishers.PublishEventstreams(workspace);
+    }
+
+    /// <summary>
+    /// Placeholder implementation of unpublish_all_orphan_items.
+    /// </summary>
+    public static void UnpublishAllOrphanItems(FabricWorkspace workspace)
+    {
+        workspace.RefreshDeployedItems();
+        Console.WriteLine("Unpublishing orphaned items");
+    }
+}

--- a/FabricCicd.Console/FabricCicd.Console.csproj
+++ b/FabricCicd.Console/FabricCicd.Console.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+</Project>

--- a/FabricCicd.Console/Program.cs
+++ b/FabricCicd.Console/Program.cs
@@ -1,0 +1,33 @@
+using System.CommandLine;
+using FabricCicd;
+
+var root = new RootCommand("Fabric CICD CLI");
+
+var workspaceOption = new Option<string>("--workspace-id", description: "Workspace ID");
+var repoOption = new Option<string>("--repo", description: "Repository directory") { IsRequired = true };
+var itemOption = new Option<string[]>("--items", description: "Item types", getDefaultValue: () => new string[0]);
+
+var publishCmd = new Command("publish-all", "Publish all items");
+publishCmd.AddOption(workspaceOption);
+publishCmd.AddOption(repoOption);
+publishCmd.AddOption(itemOption);
+publishCmd.SetHandler((string workspaceId, string repo, string[] items) =>
+{
+    var ws = new FabricWorkspace(workspaceId, repo, items);
+    Publish.PublishAllItems(ws);
+}, workspaceOption, repoOption, itemOption);
+
+var unpublishCmd = new Command("unpublish-orphan", "Unpublish orphaned items");
+unpublishCmd.AddOption(workspaceOption);
+unpublishCmd.AddOption(repoOption);
+unpublishCmd.AddOption(itemOption);
+unpublishCmd.SetHandler((string workspaceId, string repo, string[] items) =>
+{
+    var ws = new FabricWorkspace(workspaceId, repo, items);
+    Publish.UnpublishAllOrphanItems(ws);
+}, workspaceOption, repoOption, itemOption);
+
+root.AddCommand(publishCmd);
+root.AddCommand(unpublishCmd);
+
+return await root.InvokeAsync(args);

--- a/FabricCicd.Tests/FabricCicd.Tests.csproj
+++ b/FabricCicd.Tests/FabricCicd.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FabricCicd.Console\FabricCicd.Console.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FabricCicd.Tests/GlobalUsings.cs
+++ b/FabricCicd.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/FabricCicd.Tests/PublishTests.cs
+++ b/FabricCicd.Tests/PublishTests.cs
@@ -1,0 +1,13 @@
+using FabricCicd;
+
+namespace FabricCicd.Tests;
+
+public class PublishTests
+{
+    [Fact]
+    public void PublishAllRuns()
+    {
+        var ws = new FabricWorkspace("id", "/repo", new[] { "Notebook", "Report" });
+        Publish.PublishAllItems(ws);
+    }
+}

--- a/FabricCicd.Tests/UnitTest1.cs
+++ b/FabricCicd.Tests/UnitTest1.cs
@@ -1,0 +1,13 @@
+using FabricCicd;
+
+namespace FabricCicd.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void WorkspaceInitialization()
+    {
+        var ws = new FabricWorkspace("id", "/repo", new[] { "Notebook" });
+        Assert.Equal("id", ws.WorkspaceId);
+    }
+}

--- a/FabricCicd.sln
+++ b/FabricCicd.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FabricCicd.Console", "FabricCicd.Console\FabricCicd.Console.csproj", "{D394E8EA-25FC-41F5-9390-AD16B9D6D42C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FabricCicd.Tests", "FabricCicd.Tests\FabricCicd.Tests.csproj", "{AB71E419-F186-443B-94AD-2D05FEF0EB7A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D394E8EA-25FC-41F5-9390-AD16B9D6D42C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D394E8EA-25FC-41F5-9390-AD16B9D6D42C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D394E8EA-25FC-41F5-9390-AD16B9D6D42C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D394E8EA-25FC-41F5-9390-AD16B9D6D42C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB71E419-F186-443B-94AD-2D05FEF0EB7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB71E419-F186-443B-94AD-2D05FEF0EB7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB71E419-F186-443B-94AD-2D05FEF0EB7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB71E419-F186-443B-94AD-2D05FEF0EB7A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -35,3 +35,25 @@ pip install fabric-cicd
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+## .NET Usage
+
+This repository now includes a .NET 8 solution that exposes a console application.
+
+### Build
+
+```bash
+dotnet build
+```
+
+### Run
+
+```bash
+dotnet run --project FabricCicd.Console -- publish-all --repo <path> --workspace-id <id> --items Notebook
+```
+
+### Test
+
+```bash
+dotnet test
+```


### PR DESCRIPTION
## Summary
- flesh out constants with item lists and retry settings
- add Common `File` and `Item` classes
- create `ItemPublishers` helpers for each item type
- expand `Publish` to call item helpers
- add placeholder unit test for publish workflow

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849e275f9ac832dbef7d7fd8fa0e1ef