### PR TITLE
Add Fabric API client for .NET

### DIFF
--- a/FabricCicd.Console/Fabric/FabricEndpoint.cs
+++ b/FabricCicd.Console/Fabric/FabricEndpoint.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+
+namespace FabricCicd;
+
+/// <summary>
+/// Handles authentication and HTTP interactions with the Fabric API.
+/// This is a minimal counterpart to the Python FabricEndpoint class.
+/// </summary>
+public class FabricEndpoint
+{
+    private readonly TokenCredential _credential;
+    private readonly HttpClient _client;
+    private string? _token;
+    private DateTimeOffset _tokenExpires = DateTimeOffset.MinValue;
+
+    public FabricEndpoint(TokenCredential? credential = null, HttpClient? client = null)
+    {
+        _credential = credential ?? new DefaultAzureCredential();
+        _client = client ?? new HttpClient();
+    }
+
+    private async Task RefreshTokenAsync()
+    {
+        if (_token == null || _tokenExpires < DateTimeOffset.UtcNow)
+        {
+            var ctx = await _credential.GetTokenAsync(new TokenRequestContext(new[] { "https://api.fabric.microsoft.com/.default" }));
+            _token = ctx.Token;
+            _tokenExpires = ctx.ExpiresOn;
+        }
+    }
+
+    /// <summary>
+    /// Invokes an HTTP request against the Fabric API and returns the JSON body.
+    /// </summary>
+    public async Task<JsonDocument> InvokeAsync(HttpMethod method, string url, object? body = null)
+    {
+        await RefreshTokenAsync().ConfigureAwait(false);
+
+        using var request = new HttpRequestMessage(method, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        request.Headers.UserAgent.ParseAdd(Constants.UserAgent);
+
+        if (body != null)
+        {
+            var json = JsonSerializer.Serialize(body);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        using var response = await _client.SendAsync(request).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        return await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
+    }
+}

--- a/FabricCicd.Console/Fabric/FabricWorkspace.cs
+++ b/FabricCicd.Console/Fabric/FabricWorkspace.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Core;
 
 namespace FabricCicd;
 
@@ -10,12 +15,15 @@ public class FabricWorkspace
     public string WorkspaceId { get; }
     public string RepositoryDirectory { get; }
     public IList<string> ItemTypes { get; }
+    public FabricEndpoint Endpoint { get; }
+    public IDictionary<string, Dictionary<string, string>> DeployedItems { get; } = new Dictionary<string, Dictionary<string, string>>();
 
-    public FabricWorkspace(string workspaceId, string repositoryDirectory, IEnumerable<string> itemTypes)
+    public FabricWorkspace(string workspaceId, string repositoryDirectory, IEnumerable<string> itemTypes, TokenCredential? credential = null)
     {
         WorkspaceId = workspaceId ?? throw new ArgumentNullException(nameof(workspaceId));
         RepositoryDirectory = repositoryDirectory ?? throw new ArgumentNullException(nameof(repositoryDirectory));
         ItemTypes = itemTypes?.ToList() ?? throw new ArgumentNullException(nameof(itemTypes));
+        Endpoint = new FabricEndpoint(credential);
     }
 
     // TODO: Add full implementation of methods from fabric_workspace.py
@@ -24,20 +32,49 @@ public class FabricWorkspace
         // Placeholder for scanning repo directory
     }
 
-    public void RefreshDeployedItems()
+    public async Task RefreshDeployedItemsAsync()
     {
-        // Placeholder for calling Fabric API
+        var url = $"{Constants.DefaultApiRootUrl}/v1/workspaces/{WorkspaceId}/items";
+        var json = await Endpoint.InvokeAsync(HttpMethod.Get, url).ConfigureAwait(false);
+
+        DeployedItems.Clear();
+        if (json.RootElement.TryGetProperty("value", out var items))
+        {
+            foreach (var item in items.EnumerateArray())
+            {
+                var type = item.GetProperty("type").GetString() ?? string.Empty;
+                var name = item.GetProperty("displayName").GetString() ?? string.Empty;
+                var id = item.GetProperty("id").GetString() ?? string.Empty;
+
+                if (!DeployedItems.ContainsKey(type))
+                {
+                    DeployedItems[type] = new Dictionary<string, string>();
+                }
+                DeployedItems[type][name] = id;
+            }
+        }
     }
 
+    public async Task PublishItemAsync(string name, string itemType, object definition)
+    {
+        var url = $"{Constants.DefaultApiRootUrl}/v1/workspaces/{WorkspaceId}/items";
+        var body = new { type = itemType, displayName = name, config = definition };
+        await Endpoint.InvokeAsync(HttpMethod.Post, url, body).ConfigureAwait(false);
+    }
+
+    public async Task UnpublishItemAsync(string id)
+    {
+        var url = $"{Constants.DefaultApiRootUrl}/v1/workspaces/{WorkspaceId}/items/{id}";
+        await Endpoint.InvokeAsync(HttpMethod.Delete, url).ConfigureAwait(false);
+    }
+
+    // Convenience synchronous wrappers
     public void PublishItem(string name, string itemType)
-    {
-        // Placeholder publish logic
-        Console.WriteLine($"Publishing {itemType} {name}");
-    }
+        => PublishItemAsync(name, itemType, new { }).GetAwaiter().GetResult();
 
-    public void UnpublishItem(string name, string itemType)
-    {
-        // Placeholder unpublish logic
-        Console.WriteLine($"Unpublishing {itemType} {name}");
-    }
+    public void PublishItem(string name, string itemType, object definition)
+        => PublishItemAsync(name, itemType, definition).GetAwaiter().GetResult();
+
+    public void UnpublishItem(string id)
+        => UnpublishItemAsync(id).GetAwaiter().GetResult();
 }

--- a/FabricCicd.Console/FabricCicd.Console.csproj
+++ b/FabricCicd.Console/FabricCicd.Console.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- implement `FabricEndpoint` with basic token auth and request logic
- extend `FabricWorkspace` to use the API client and expose async publish/unpublish methods
- reference `Azure.Identity` in the console project

## Testing
- `pytest -q` *(fails: 5 errors)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2a6d4878832d9c26f321fdaed988